### PR TITLE
Coverage vis toggle (#1572)

### DIFF
--- a/plugin/mutate/data/source.css
+++ b/plugin/mutate/data/source.css
@@ -79,7 +79,10 @@ span.xx_label {
     background: lightblue;
 }
 .loc_noncovered {
-    background: orangered;
+    background: rgb(255, 217, 0);
+}
+.loc_coverage_off {
+    background-color: #ffffff;
 }
 #filter_wrapper {
     display: block;

--- a/plugin/mutate/data/source.html
+++ b/plugin/mutate/data/source.html
@@ -26,6 +26,11 @@
     </td>
     <td><input id="show_mutant" type="checkbox" checked onclick='click_show_mutant(this)'/><span class="xx_label">Show</span></td>
   </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td><input id="show_coverage" type="checkbox" checked onclick='click_show_coverage(this)'/><span class="xx_label">Coverage</span></td>
+  </tr>
 </table>
 <div id="filter_wrapper">
 <p class="filter_title">Testcases to display</p>
@@ -57,6 +62,10 @@
   <tr id="legend5">
     <td><span id="legend5_action" class="xx_label"></span></td>
     <td><span id="legend5_key"></span></td>
+  </tr>
+  <tr id="legend6">
+    <td><span id="legend6_action" class="xx_label"></span></td>
+    <td><span id="legend6_key"></span></td>
   </tr>
 </table>
 </div>

--- a/plugin/mutate/data/source.js
+++ b/plugin/mutate/data/source.js
@@ -14,6 +14,7 @@ const LOC_SCROLL_TO_ON_TRAVERSE = true;
 
 var g_displayed_testcases = 10; //Number of testcases displayed in the info line
 var g_show_mutant = true;
+var g_show_coverage = true;
 var g_active_mutid = 0;
 var g_active_locid = null;
 var g_loc_mutids = {};
@@ -25,6 +26,7 @@ var key_traverse_locs_down = 'ArrowDown';
 var key_traverse_muts_up = 'ArrowLeft';
 var key_traverse_muts_down = 'ArrowRight';
 var key_toggle_show_mutant = 'Numpad0';
+var key_toggle_show_coverage = 'Numpad1';
 
 
 /**
@@ -122,6 +124,9 @@ function on_keyboard_input(e) {
         case key_toggle_show_mutant:
             document.getElementById("show_mutant").checked = !document.getElementById("show_mutant").checked
             click_show_mutant();
+        case key_toggle_show_coverage:
+            document.getElementById("show_coverage").checked = !document.getElementById("show_coverage").checked
+            click_show_coverage();
     }
     return;
 }
@@ -433,6 +438,19 @@ function click_show_mutant() {
     }
 }
 /**
+ * Toggles the visibility of color for covered and non-covered lines
+ */
+function click_show_coverage() {
+    coverageClasses = document.querySelectorAll('.loc_covered');
+    coverageClasses.forEach(element => {
+        element.classList.toggle('loc_coverage_off');
+    })
+    nonCoverageClasses = document.querySelectorAll('.loc_noncovered');
+    nonCoverageClasses.forEach(element => {
+        element.classList.toggle('loc_coverage_off');
+    })
+}
+/**
  * Activates the mutant of the given id.
  * @param {id} mutid id of the mutant to activate
  */
@@ -576,11 +594,13 @@ function init_legend() {
    document.getElementById("legend3_action").innerHTML = "Next mutant: ";
    document.getElementById("legend4_action").innerHTML = "Prev mutant: ";
    document.getElementById("legend5_action").innerHTML = "Toggle show: ";
+   document.getElementById("legend5_action").innerHTML = "Toggle coverage: ";
    document.getElementById("legend1_key").innerHTML = key_traverse_locs_down;
    document.getElementById("legend2_key").innerHTML = key_traverse_locs_up;
    document.getElementById("legend3_key").innerHTML = key_traverse_muts_down;
    document.getElementById("legend4_key").innerHTML = key_traverse_muts_up;
    document.getElementById("legend5_key").innerHTML = key_toggle_show_mutant;
+   document.getElementById("legend6_key").innerHTML = key_toggle_show_coverage;
 }
 function init_filter_kind() {
     var table = document.getElementById("filter_kind");

--- a/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
+++ b/plugin/mutate/source/dextool/plugin/mutate/backend/report/html/package.d
@@ -680,7 +680,6 @@ bool[uint] extractLineCovData(CovRegionStatus[] dbData, ref FileCtx ctx) {
     return lineList;
 }
 
-
 void generateFile(ref Database db, ref FileCtx ctx) @trusted {
     import std.conv : to;
     import std.range : repeat, enumerate;
@@ -735,9 +734,9 @@ void generateFile(ref Database db, ref FileCtx ctx) @trusted {
 
             if (auto v = (lastLoc.line + i + 1) in lineList) {
                 if (*v)
-                    line.addClass("loc_covered");
+                    line.firstChild.addClass("loc_covered");
                 else
-                    line.addClass("loc_noncovered");
+                    line.firstChild.addClass("loc_noncovered");
             }
 
             // force a newline in the generated html to improve readability
@@ -755,8 +754,8 @@ void generateFile(ref Database db, ref FileCtx ctx) @trusted {
                 addClass(v);
             if (s.muts.length != 0) {
                 addClass(format("%(mutid%s %)", s.muts.map!(a => a.id)));
-                line.removeClass("loc_covered");
-                line.removeClass("loc_noncovered");
+                line.firstChild.removeClass("loc_covered");
+                line.firstChild.removeClass("loc_noncovered");
             }
             if (meta.onClick.length != 0)
                 setAttribute("onclick", meta.onClick);


### PR DESCRIPTION
* coverage toggle button added, only line number is colored by coverage, numpad1 also toggles coverage

* changed color for noncovered lines

Co-authored-by: Viktor N <v.norgren01@gmail.com>